### PR TITLE
Keep message pointer valid by binding CString

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -55,9 +55,10 @@ impl PamConv {
     /// styles.
     pub fn send(&self, style: PamMessageStyle, msg: &str) -> PamResult<Option<String>> {
         let mut resp_ptr: *const PamResponse = ptr::null();
+        let msg_text = CString::new(msg).unwrap();
         let msg = PamMessage {
             msg_style: style,
-            msg: CString::new(msg).unwrap().as_ptr(),
+            msg: msg_text.as_ptr(),
         };
 
         let ret = (self.conv)(1, &&msg, &mut resp_ptr, self.appdata_ptr);


### PR DESCRIPTION
From the docs of `as_ptr()`:

> It is your responsibility to make sure that the underlying memory is not freed too early. For example, the following code will cause undefined behavior when ptr is used inside the unsafe block:
> ```rust
> use std::ffi::CString;
>
> let ptr = CString::new("Hello").expect("CString::new failed").as_ptr();
> unsafe {
>     // `ptr` is dangling
>     *ptr;
> }
> ```

I noticed that this causes an issue in `PamConv::send`, and fixed it by binding the CString to a variable, keeping it valid through the use of the pointer.

Please let me know if there are any issues with my PR! Although it's short, I'm just learning Rust, so I would definitely appreciate correction on any pitfalls that I've fallen into :)