### PR TITLE
Clean up a bunch of unsafe pointer handling

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -55,7 +55,7 @@ impl PamConv {
     /// styles.
     pub fn send(&self, style: PamMessageStyle, msg: &str) -> PamResult<Option<String>> {
         let mut resp_ptr: *const PamResponse = ptr::null();
-        let c_msg = CString::new(msg).unwrap();
+        let c_msg = CString::new(msg).map_err(|_| PAM_SYSTEM_ERR)?;
         let msg = PamMessage {
             msg_style: style,
             msg: c_msg.as_ptr(),

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -55,9 +55,10 @@ impl PamConv {
     /// styles.
     pub fn send(&self, style: PamMessageStyle, msg: &str) -> PamResult<Option<String>> {
         let mut resp_ptr: *const PamResponse = ptr::null();
+        let c_msg = CString::new(msg).unwrap();
         let msg = PamMessage {
             msg_style: style,
-            msg: CString::new(msg).unwrap().as_ptr(),
+            msg: c_msg.as_ptr(),
         };
 
         let ret = (self.conv)(1, &&msg, &mut resp_ptr, self.appdata_ptr);

--- a/src/module.rs
+++ b/src/module.rs
@@ -76,9 +76,9 @@ pub trait PamItem {
 /// See `pam_get_data` in
 /// http://www.linux-pam.org/Linux-PAM-html/mwg-expected-by-module-item.html
 pub unsafe fn get_data<'a, T>(pamh: &'a PamHandleT, key: &str) -> PamResult<&'a T> {
-    let c_key = CString::new(key).unwrap().as_ptr();
+    let c_key = CString::new(key).unwrap();
     let mut ptr: *const PamDataT = ptr::null();
-    let res = pam_get_data(pamh, c_key, &mut ptr);
+    let res = pam_get_data(pamh, c_key.as_ptr(), &mut ptr);
     if constants::PAM_SUCCESS == res && !ptr.is_null() {
         let typed_ptr: *const T = mem::transmute(ptr);
         let data: &T = &*typed_ptr;
@@ -95,10 +95,10 @@ pub unsafe fn get_data<'a, T>(pamh: &'a PamHandleT, key: &str) -> PamResult<&'a 
 /// See `pam_set_data` in
 /// http://www.linux-pam.org/Linux-PAM-html/mwg-expected-by-module-item.html
 pub fn set_data<T>(pamh: &PamHandleT, key: &str, data: Box<T>) -> PamResult<()> {
-    let c_key = CString::new(key).unwrap().as_ptr();
+    let c_key = CString::new(key).unwrap();
     let res = unsafe {
         let c_data: Box<PamDataT> = mem::transmute(data);
-        pam_set_data(pamh, c_key, c_data, cleanup::<T>)
+        pam_set_data(pamh, c_key.as_ptr(), c_data, cleanup::<T>)
     };
     if constants::PAM_SUCCESS == res { Ok(()) } else { Err(res) }
 }
@@ -135,10 +135,9 @@ pub fn get_item<'a, T: PamItem>(pamh: &'a PamHandleT) -> PamResult<&'a T> {
 /// http://www.linux-pam.org/Linux-PAM-html/mwg-expected-by-module-item.html
 pub fn get_user<'a>(pamh: &'a PamHandleT, prompt: Option<&str>) -> PamResult<String> {
     let ptr: *mut c_char = ptr::null_mut();
-    let c_prompt = match prompt {
-        Some(p) => CString::new(p).unwrap().as_ptr(),
-        None    => ptr::null(),
-    };
+    let prompt = prompt.map(|p| CString::new(p).unwrap());
+    let c_prompt = prompt.as_deref().map(CStr::as_ptr).unwrap_or(ptr::null());
+
     let res = unsafe { pam_get_user(pamh, &ptr, c_prompt) };
     if constants::PAM_SUCCESS == res && !ptr.is_null() {
         let const_ptr = ptr as *const c_char;


### PR DESCRIPTION
There's several instances of passing pointers to dropped `CString`s (such as the one fixed by #2) picked up by clippy; this merge request fixes all of them. It also gets rid of a few `panic`s, and a potential null dereference in `PamConv::send`.